### PR TITLE
Switch from timler to decode-development

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -18,12 +18,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build-and-deploy:
+  build:
     runs-on: ubuntu-latest
-    environment:
-      name: ${{ github.event_name == 'push' && 'github-pages' || '' }}
-      url: ${{ steps.deployment.outputs.page_url }}
-
     steps:
       # Setup phase
       - name: Checkout repository
@@ -50,14 +46,34 @@ jobs:
         run: npm run build
         continue-on-error: false
 
-      # Deploy phase - only runs on push to release (not PR)
-      - name: Upload artifact
-        if: github.event_name == 'push'
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: docusaurus-build
+          path: './build'
+
+  deploy:
+    needs: build
+    if: github.event_name == 'push' && github.ref == 'refs/heads/release'
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Setup GitHub Pages
+        uses: actions/configure-pages@v4
+
+      - name: Download build artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: docusaurus-build
+          path: './build'
+
+      - name: Upload pages artifact
         uses: actions/upload-pages-artifact@v3
         with:
           path: './build'
 
       - name: Deploy to GitHub Pages
-        if: github.event_name == 'push'
         id: deployment
         uses: actions/deploy-pages@v4

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -21,7 +21,7 @@ jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
     environment:
-      name: github-pages
+      name: ${{ github.event_name == 'push' && 'github-pages' || '' }}
       url: ${{ steps.deployment.outputs.page_url }}
 
     steps:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # FASP QAT Documentation
 
-[![Documentation CI](https://github.com/timler/fasp-documentation/actions/workflows/documentation.yml/badge.svg)](https://github.com/timler/fasp-documentation/actions/workflows/documentation.yml)
+[![Documentation CI](
+https://github.com/decode-development/fasp-documentation/actions/workflows/documentation.yml/badge.svg)](https://github.com/decode-development/fasp-documentation/actions/workflows/documentation.yml)
 
 This repository contains the documentation website for the FASP Quantification Analytics Tool (QAT), built using [Docusaurus](https://docusaurus.io/).
 
@@ -8,7 +9,7 @@ This repository contains the documentation website for the FASP Quantification A
 
 ### Accessing the Documentation
 
-You can read the documentation at [https://timler.github.io/fasp-documentation/](https://timler.github.io/fasp-documentation/). 
+You can read the documentation at [https://decode-development.github.io/fasp-documentation/](https://decode-development.github.io/fasp-documentation/). 
 
 The documentation is organized into sections:
 
@@ -93,7 +94,7 @@ This documentation website is built using [Docusaurus](https://docusaurus.io/), 
 #### Check out the project
 
 ```bash
-git clone git@github.com:timler/fasp-documentation.git
+git clone git@github.com:decode-development/fasp-documentation.git
 cd fasp-documentation
 ```
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -7,7 +7,7 @@
 import {themes as prismThemes} from 'prism-react-renderer';
 
 /** define the GIT repository details */
-const orgName = 'timler';
+const orgName = 'decode-development';
 const projectName = 'fasp-documentation';
 const repoRoot = `https://github.com/${orgName}/${projectName}`;
 const apiDownloadUrl = `https://raw.githubusercontent.com/${orgName}/${projectName}/main/documentation/static/api/`;


### PR DESCRIPTION
Switch all the references to my personal git repo to the decode- development one so that the build badge and CI can run properly